### PR TITLE
Fix wrong threshold computation when a single element is used for testing

### DIFF
--- a/src/anomalib/utils/metrics/optimal_f1.py
+++ b/src/anomalib/utils/metrics/optimal_f1.py
@@ -64,7 +64,11 @@ class OptimalF1(Metric):
         else:
             precision, recall, thresholds = self.precision_recall_curve.compute()
             f1_score = (2 * precision * recall) / (precision + recall + 1e-10)
-            self.threshold = thresholds[torch.argmax(f1_score)]
+            if thresholds.nelement() == 1:
+                # Particular case when f1 score is 1 and the threshold is unique
+                self.threshold = thresholds
+            else:
+                self.threshold = thresholds[torch.argmax(f1_score)]
             optimal_f1_score = torch.max(f1_score)
             return optimal_f1_score
 


### PR DESCRIPTION
Description

fix: Fix optimal f1 score computation failing when there's only a single image per class

Cause:

When an anomaly test is done using a single image per class (Eg. 5 good 1 bad, 1 good 5 bad) the f1 score computation fails.

Resolution:

Changed the underlying logic so that if the scenario above is presented it’s dealt with properly instead of breaking.