### PR TITLE
feat: Better management efficient_ad non squared inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0+obx.1.2.4]
+
+### Fixed
+
+- Fix efficient_ad memory footprint
+
+### Changed
+
+- Better management of non-squared inputs in efficient_ad
+
 ## [v0.7.0+obx.1.2.3]
 
 ### Fixed

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.2.3"
+custom_orobix_version = "1.2.4"
 
 __version__ = f"{anomalib_version}+obx.{custom_orobix_version}"

--- a/src/anomalib/models/efficient_ad/lightning_model.py
+++ b/src/anomalib/models/efficient_ad/lightning_model.py
@@ -168,18 +168,17 @@ class EfficientAd(AnomalyModule):
             dict[str, Tensor]: Dictionary of channel-wise mean and std
         """
         y_means = []
-        teacher_outputs = []
         means_distance = []
 
         logger.info("Calculate teacher channel mean and std")
         for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel mean", position=0, leave=True):
             y = self.model.teacher(batch["image"].to(self.device))
             y_means.append(torch.mean(y, dim=[0, 2, 3]))
-            teacher_outputs.append(y)
 
         channel_mean = torch.mean(torch.stack(y_means), dim=0)[None, :, None, None]
 
-        for y in tqdm.tqdm(teacher_outputs, desc="Calculate teacher channel std", position=0, leave=True):
+        for batch in tqdm.tqdm(dataloader, desc="Calculate teacher channel std", position=0, leave=True):
+            y = self.model.teacher(batch["image"].to(self.device))
             distance = (y - channel_mean) ** 2
             means_distance.append(torch.mean(distance, dim=[0, 2, 3]))
 


### PR DESCRIPTION
## Description
Old pr. Check if better management of non squared inputs is still a good idea.

## Changes

Removing an useless list reduce significantly efficient_ad memory footprint. This fix has been taken from a closed anomalib pr. I opened this pr in order to inject this improvement as fast as possible in our fork too (only 3 lines of code).

- [x] New feature (non-breaking change which adds functionality)


</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
