### PR TITLE
feature/keep-efficientad-maps-on-gpu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0+obx.1.2.6]
+
+### Updated
+
+- Efficient_ad model's forward doesn't need to move maps on cpu to obtain determinism (after quadra 1.3.6 cuBLAS env variable hotfix)
+
 ## [v0.7.0+obx.1.2.5]
 
 ### Fixed

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.2.5"
+custom_orobix_version = "1.2.6"
 
 __version__ = f"{anomalib_version}+obx.{custom_orobix_version}"

--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -446,7 +446,6 @@ class EfficientAdModel(nn.Module):
                 ae_output = self.ae(batch)
 
             map_st = torch.mean(distance_st, dim=1, keepdim=True)
-            current_device = map_st.get_device()
 
             if student_output.shape != ae_output.shape:
                 student_output = F.interpolate(student_output, size=ae_output.shape[2:])
@@ -461,19 +460,13 @@ class EfficientAdModel(nn.Module):
 
             # To obtain smooth maps we need to use "bilinear".
             # Given the non-determinism of this strategy we have to compute it on cpu
-            map_st = F.interpolate(map_st.cpu(), size=(self.input_size[0], self.input_size[1]), mode="bilinear")
-            map_stae = F.interpolate(map_stae.cpu(), size=(self.input_size[0], self.input_size[1]), mode="bilinear")
+            map_st = F.interpolate(map_st, size=(self.input_size[0], self.input_size[1]), mode="bilinear")
+            map_stae = F.interpolate(map_stae, size=(self.input_size[0], self.input_size[1]), mode="bilinear")
 
             if self.is_set(self.quantiles):
-                map_st = (
-                    0.1
-                    * (map_st.to(current_device) - self.quantiles["qa_st"])
-                    / (self.quantiles["qb_st"] - self.quantiles["qa_st"])
-                )
+                map_st = 0.1 * (map_st - self.quantiles["qa_st"]) / (self.quantiles["qb_st"] - self.quantiles["qa_st"])
                 map_stae = (
-                    0.1
-                    * (map_stae.to(current_device) - self.quantiles["qa_ae"])
-                    / (self.quantiles["qb_ae"] - self.quantiles["qa_ae"])
+                    0.1 * (map_stae - self.quantiles["qa_ae"]) / (self.quantiles["qb_ae"] - self.quantiles["qa_ae"])
                 )
             # We interpolate after combining the maps, as it returns better results w/ the padding
             map_combined = 0.5 * map_st + 0.5 * map_stae

--- a/src/anomalib/models/efficient_ad/torch_model.py
+++ b/src/anomalib/models/efficient_ad/torch_model.py
@@ -472,7 +472,7 @@ class EfficientAdModel(nn.Module):
             map_combined = 0.5 * map_st + 0.5 * map_stae
 
             # map_combined = torch.nn.functional.pad(map_combined, (4, 4, 4, 4))
-            # output = F.interpolate(map_combined.cpu(), size=(self.input_size[0], self.input_size[1]), mode="bilinear")
+            # output = F.interpolate(map_combined, size=(self.input_size[0], self.input_size[1]), mode="bilinear")
 
             anomaly_score = map_combined.reshape((map_combined.shape[0], -1)).max(1)[0]
 


### PR DESCRIPTION
## Description

Eficient_ad maps are now kept on gpu.


## Changes
Remove the st_maps and stae_maps "device switch" in efficient_ad forward
<details>
<summary>Describe the changes you made</summary>

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Refactor (non-breaking change which refactors the code base)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

</details>

## Checklist

<details>
<summary>Ensure that you followed the following</summary>

- [ ] I have added a summary of my changes to the [CHANGELOG](https://github.com/openvinotoolkit/anomalib/blob/main/CHANGELOG.md) (not for minor changes, docs and tests).
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas (If applicable)
- [ ] I have made corresponding changes to the documentation (If applicable)
- [ ] I have added tests that prove my fix is effective or that my feature works (If applicable)

</details>
