### PR TITLE
Compute the optimal threshold as average between the max good and min bad score when the F1 is 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0+obx.1.3.1]
+
+### Updated
+
+- Compute the optimal threshold as average between the max good and min bad score when the F1 is 1
+
 ## [v0.7.0+obx.1.3.0]
 
 ### Updated

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.3.0"
+custom_orobix_version = "1.3.1"
 
 __version__ = f"{anomalib_version}+obx.{custom_orobix_version}"


### PR DESCRIPTION
## Description

Right now when there's a gap between the good samples and the bad ones and the anomaly score is 1 we select as threshold the minimum of bad scores, this is suboptimal as it doesn't make good usage of the existing gap.
With this PR if the F1 score is 1 the threshold is instead computed as the average between the max of good scores and min of bad scores

This is in example of the old behaviour
![cumulative_histogram](https://github.com/orobix/anomalib/assets/14907613/31b39f10-41c3-47ab-893e-e9644fc51b5b)

And the new one

![cumulative_histogram_new](https://github.com/orobix/anomalib/assets/14907613/cbabe340-734a-4bac-81e8-3a06f64f7fae)
