### PR TITLE
Feature/patchore max anomaly score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0+obx.1.3.4]
+
+### Added
+
+- Add three new flags to change the anomaly computation for patchcore
+    - `disable_score_weighting` which disables reweighting the anomaly score based on the anomalib formula
+    - `weight_anomaly_map` which apply the same weight used for the anomaly score to the whole anomaly map
+    - `anomaly_score_from_max_heatmap` which computes the anomaly score from the max value of the anomaly map
+
+    The latter is the one impacting the most the anomaly score computation as it will extract the max of the anomaly
+    map after the application of the pooling, this is the only way ensuring that the anomaly score is the maximum
+    value of the anomaly map. Disable score weighting should only be used if this flag is set to False, otherwise the
+    anomaly score will be replaced by the max of the anomaly map.
+
 ## [v0.7.0+obx.1.3.3]
 
 ### Fixed

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.3.3"
+custom_orobix_version = "1.3.4"
 
 __version__ = f"{anomalib_version}+obx.{custom_orobix_version}"

--- a/src/anomalib/models/patchcore/lightning_model.py
+++ b/src/anomalib/models/patchcore/lightning_model.py
@@ -35,10 +35,16 @@ class Patchcore(AnomalyModule):
         num_neighbors (int, optional): Number of nearest neighbors. Defaults to 9.
         pretrained_weights (str, optional): Path to pretrained weights. Defaults to None.
         compress_memory_bank (bool): If true the memory bank features are projected to a lower dimensionality following
-        the Johnson-Lindenstrauss lemma.
+            the Johnson-Lindenstrauss lemma.
         coreset_sampler (str): Coreset sampler to use. Defaults to "anomalib".
         score_computation (str): Score computation to use. Defaults to "anomalib". If "amazon" is used, the anomaly
-        score is correctly computed as from the paper but it may require more time to compute.
+            score is correctly computed as from the paper but it may require more time to compute.
+        disable_score_weighting: If true, the model will not apply the weight factor to the anomaly score. Only works if
+            score_computation is set to anomalib.
+        weight_anomaly_map: If true, the model will apply the weight factor to the whole anomaly map, this might be
+            useful as the anomaly score is now the max of the anomaly map. Only enabled if disable_score_weighting is
+            False. Only works if score_computation is set to anomalib.
+        anomaly_score_from_max_heatmap: If true, the anomaly score will be the max of the anomaly map.
     """
 
     def __init__(
@@ -53,6 +59,9 @@ class Patchcore(AnomalyModule):
         compress_memory_bank: bool = False,
         coreset_sampler: str = "anomalib",
         score_computation: str = "anomalib",
+        disable_score_weighting: bool = False,
+        weight_anomaly_map: bool = False,
+        anomaly_score_from_max_heatmap: bool = False,
     ) -> None:
         super().__init__()
 
@@ -65,6 +74,9 @@ class Patchcore(AnomalyModule):
             pretrained_weights=pretrained_weights,
             compress_memory_bank=compress_memory_bank,
             score_computation=score_computation,
+            disable_score_weighting=disable_score_weighting,
+            weight_anomaly_map=weight_anomaly_map,
+            anomaly_score_from_max_heatmap=anomaly_score_from_max_heatmap,
         )
         self.coreset_sampling_ratio = coreset_sampling_ratio
         self.embeddings: list[Tensor] = []
@@ -168,6 +180,9 @@ class PatchcoreLightning(Patchcore):
             compress_memory_bank=getattr(hparams.model, "compress_memory_bank", False),
             coreset_sampler=getattr(hparams.model, "coreset_sampler", "anomalib"),
             score_computation=getattr(hparams.model, "score_computation", "anomalib"),
+            disable_score_weighting=getattr(hparams.model, "disable_score_weighting", False),
+            weight_anomaly_map=getattr(hparams.model, "weight_anomaly_map", False),
+            anomaly_score_from_max_heatmap=getattr(hparams.model, "anomaly_score_from_max_heatmap", False),
         )
         self.hparams: DictConfig | ListConfig  # type: ignore
         self.save_hyperparameters(hparams)


### PR DESCRIPTION
## [v0.7.0+obx.1.3.4]

### Added

- Add three new flags to change the anomaly computation for patchcore
    - `disable_score_weighting` which disables reweighting the anomaly score based on the anomalib formula
    - `weight_anomaly_map` which apply the same weight used for the anomaly score to the whole anomaly map
    - `anomaly_score_from_max_heatmap` which computes the anomaly score from the max value of the anomaly map

    The latter is the one impacting the most the anomaly score computation as it will extract the max of the anomaly
    map after the application of the pooling, this is the only way ensuring that the anomaly score is the maximum
    value of the anomaly map. Disable score weighting should only be used if this flag is set to False, otherwise the
    anomaly score will be replaced by the max of the anomaly map.