### PR TITLE
Feature/remove opencv python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0.dev141]
+
+### Updated
+
+- Remove imgaug from mandatory dependencies to remove the necessity of installing opencv-python which conflicts with the headless version on Windows.
+
 ## [v0.7.0.dev140]
 
 ### Updated

--- a/poetry.lock
+++ b/poetry.lock
@@ -1127,7 +1127,7 @@ files = [
 name = "imageio"
 version = "2.34.2"
 description = "Library for reading and writing a wide range of image, video, scientific, and volumetric data formats."
-optional = false
+optional = true
 python-versions = ">=3.8"
 files = [
     {file = "imageio-2.34.2-py3-none-any.whl", hash = "sha256:a0bb27ec9d5bab36a9f4835e51b21d2cb099e1f78451441f94687ff3404b79f8"},
@@ -1159,7 +1159,7 @@ tifffile = ["tifffile"]
 name = "imgaug"
 version = "0.4.0"
 description = "Image augmentation library for deep neural networks"
-optional = false
+optional = true
 python-versions = "*"
 files = [
     {file = "imgaug-0.4.0-py2.py3-none-any.whl", hash = "sha256:ce61e65b4eb7405fc62c1b0a79d2fa92fd47f763aaecb65152d29243592111f9"},
@@ -1198,7 +1198,7 @@ testing = ["jaraco.test (>=5.4)", "pytest (>=6)", "pytest-checkdocs (>=2.4)", "p
 [[package]]
 name = "intel-openmp"
 version = "2021.4.0"
-description = "Intel® OpenMP* Runtime Library"
+description = "Intel OpenMP* Runtime Library"
 optional = false
 python-versions = "*"
 files = [
@@ -1396,7 +1396,7 @@ x = ["accelerate (==0.8.0)", "dataclasses"]
 name = "lazy-loader"
 version = "0.4"
 description = "Makes it easy to load subpackages and functions on demand."
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "lazy_loader-0.4-py3-none-any.whl", hash = "sha256:342aa8e14d543a154047afb4ba8ef17f5563baad3fc610d7b15b213b0f119efc"},
@@ -2048,7 +2048,7 @@ PyYAML = ">=5.1.0"
 name = "opencv-python"
 version = "4.10.0.84"
 description = "Wrapper package for OpenCV python bindings."
-optional = false
+optional = true
 python-versions = ">=3.6"
 files = [
     {file = "opencv-python-4.10.0.84.tar.gz", hash = "sha256:72d234e4582e9658ffea8e9cae5b63d488ad06994ef12d81dc303b17472f3526"},
@@ -2388,7 +2388,7 @@ name = "psutil"
 version = "6.0.0"
 description = "Cross-platform lib for process and system monitoring in Python."
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,>=2.7"
 files = [
     {file = "psutil-6.0.0-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a021da3e881cd935e64a3d0a20983bda0bb4cf80e4f74fa9bfcb1bc5785360c6"},
     {file = "psutil-6.0.0-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:1287c2b95f1c0a364d23bc6f2ea2365a8d4d9b726a3be7294296ff7ba97c17f0"},
@@ -2805,7 +2805,7 @@ jupyter = ["ipywidgets (>=7.5.1,<9)"]
 name = "scikit-image"
 version = "0.24.0"
 description = "Image processing in Python"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "scikit_image-0.24.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:cb3bc0264b6ab30b43c4179ee6156bc18b4861e78bb329dd8d16537b7bbf827a"},
@@ -3060,7 +3060,7 @@ test = ["build[virtualenv] (>=1.0.3)", "filelock (>=3.4.0)", "importlib-metadata
 name = "shapely"
 version = "2.0.4"
 description = "Manipulation and analysis of geometric objects"
-optional = false
+optional = true
 python-versions = ">=3.7"
 files = [
     {file = "shapely-2.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:011b77153906030b795791f2fdfa2d68f1a8d7e40bce78b029782ade3afe4f2f"},
@@ -3220,7 +3220,7 @@ files = [
 name = "tifffile"
 version = "2024.7.2"
 description = "Read and write TIFF files"
-optional = false
+optional = true
 python-versions = ">=3.9"
 files = [
     {file = "tifffile-2024.7.2-py3-none-any.whl", hash = "sha256:5a2ee608c9cc1f2e044d943dacebddc71d4827b6fad150ef4c644b7aefbe2d1a"},
@@ -3861,7 +3861,10 @@ files = [
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", "jaraco.test", "more-itertools", "pytest (>=6,!=8.1.*)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-ignore-flaky", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
 
+[extras]
+augmentation = ["imgaug"]
+
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<3.11"
-content-hash = "17dcd62cb5ce35ac1236bec916a11022e106c05651416016484d6eaf7d11a723"
+content-hash = "c3cb25269c7505eb05d4887fc792a8c1af1ad41c5109741bb1a14d2861ef13a3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anomalib-orobix"
-version = "0.7.0.dev140"
+version = "0.7.0.dev141"
 description = "Orobix anomalib fork"
 authors = [
     "Intel OpenVINO <help@openvino.intel.com>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,14 @@ omegaconf = "~2.3"
 freia = "~0.2"
 wandb = "0.12.17"
 gradio = "3.0.2"
-imgaug = "0.4.0"
 line-profiler = "3.5.1"
 jsonargparse = { version = "~4.3.0", extras = ["signatures"] }
+
+imgaug = { version = "0.4.0", optional = true }
+
+[tool.poetry.extras]
+# We make imgaug optional as it requires opencv-python instead of the headless version
+augmentation = ["imgaug"]
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # BLACK CONFIGURATION                                                         #

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.4.0"
+custom_orobix_version = "1.4.1"
 
 __version__ = f"{anomalib_version}.dev{custom_orobix_version.replace('.', '')}"

--- a/src/anomalib/data/utils/augmenter.py
+++ b/src/anomalib/data/utils/augmenter.py
@@ -9,21 +9,30 @@
 # Copyright (C) 2022 Intel Corporation
 # SPDX-License-Identifier: Apache-2.0
 
-
 from __future__ import annotations
 
 import glob
 import math
 import random
+from typing import TYPE_CHECKING
 
 import cv2
-import imgaug.augmenters as iaa
 import numpy as np
 import torch
 from torch import Tensor
 from torchvision.datasets.folder import IMG_EXTENSIONS
 
 from anomalib.data.utils.generators.perlin import random_2d_perlin
+
+try:
+    import imgaug.augmenters as iaa
+
+    IMGAUG_AVAILABLE = True
+except ImportError:
+    IMGAUG_AVAILABLE = False
+
+if TYPE_CHECKING:
+    import imgaug.augmenters as iaa
 
 
 def nextpow2(value):
@@ -47,6 +56,10 @@ class Augmenter:
         p_anomalous: float = 0.5,
         beta: float | tuple[float, float] = (0.2, 1.0),
     ):
+        if not IMGAUG_AVAILABLE:
+            raise ImportError(
+                "imgaug is not installed, anomalib requires the augmentation extra to be installed to use the Augmenter class"
+            )
         self.p_anomalous = p_anomalous
         self.beta = beta
 


### PR DESCRIPTION
## [v0.7.0.dev141]

### Updated

- Remove imgaug from mandatory dependencies to remove the necessity of installing opencv-python which conflicts with the headless version on Windows.
