### PR TITLE
Feature/improve vram usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0.dev142]
+
+### Updated
+
+- Improve VRAM usage for patchcore trainings.
+
+### Fixed
+
+- Avoid projecting features to a larger space when Johnson-Lindenstrauss lemma suggests it.
+
 ## [v0.7.0.dev141]
 
 ### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anomalib-orobix"
-version = "0.7.0.dev141"
+version = "0.7.0.dev142"
 description = "Orobix anomalib fork"
 authors = [
     "Intel OpenVINO <help@openvino.intel.com>",

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.4.1"
+custom_orobix_version = "1.4.2"
 
 __version__ = f"{anomalib_version}.dev{custom_orobix_version.replace('.', '')}"

--- a/src/anomalib/models/patchcore/lightning_model.py
+++ b/src/anomalib/models/patchcore/lightning_model.py
@@ -120,7 +120,10 @@ class Patchcore(AnomalyModule):
             if not self.trainer.sanity_checking:
                 # Initialize the embeddings tensor with the estimated number of batches
                 self.embeddings = torch.zeros(
-                    (embedding.shape[0] * (self.trainer.estimated_stepping_batches), *embedding.shape[1:]),
+                    (
+                        embedding.shape[0] * self.trainer.estimated_stepping_batches * self.trainer.max_epochs,
+                        *embedding.shape[1:],
+                    ),
                     device=self.device,
                     dtype=embedding.dtype,
                 )

--- a/src/anomalib/models/patchcore/torch_model.py
+++ b/src/anomalib/models/patchcore/torch_model.py
@@ -248,13 +248,17 @@ class PatchcoreModel(DynamicBufferModule, nn.Module):
         coreset_indices = sampler.sample_coreset(compressed_embedding)
         if self.compress_memory_bank:
             self.memory_bank = compressed_embedding[coreset_indices]
+            del compressed_embedding
         else:
             del compressed_embedding
             if torch.cuda.is_available():
                 torch.cuda.empty_cache()
-                embedding = embedding.to(original_device)
 
             self.memory_bank = embedding[coreset_indices]
+            self.memory_bank = self.memory_bank.to(original_device)
+
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
 
     def subsample_embedding_amazon(self, embedding: torch.Tensor, sampling_ratio: float) -> None:
         """Subsample embedding based on coreset sampling and store to memory.


### PR DESCRIPTION
## Description

Improve patchcore memory usage by preallocating tensors, avoid using stack and clearing cache more frequently.

Finally avoid projecting features to a larger feature space when Johnson-Lindenstrauss lemma works worse than normal (generally this only happens with a huge amount of images involved, like >5k)
