### PR TITLE
Hotfix/embeddings size computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [v0.7.0.dev143]
+
+### Fixed
+
+- Fix wrong embeddings initialization in patchcore when the dataset is smaller than the batch size.
+
 ## [v0.7.0.dev142]
 
 ### Updated

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "anomalib-orobix"
-version = "0.7.0.dev142"
+version = "0.7.0.dev143"
 description = "Orobix anomalib fork"
 authors = [
     "Intel OpenVINO <help@openvino.intel.com>",

--- a/src/anomalib/__init__.py
+++ b/src/anomalib/__init__.py
@@ -4,6 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 anomalib_version = "0.7.0"
-custom_orobix_version = "1.4.2"
+custom_orobix_version = "1.4.3"
 
 __version__ = f"{anomalib_version}.dev{custom_orobix_version.replace('.', '')}"

--- a/src/anomalib/models/patchcore/lightning_model.py
+++ b/src/anomalib/models/patchcore/lightning_model.py
@@ -121,7 +121,7 @@ class Patchcore(AnomalyModule):
                 # Initialize the embeddings tensor with the estimated number of batches
                 self.embeddings = torch.zeros(
                     (
-                        (embedding.shape[0] // self.trainer.train_dataloader.batch_size)
+                        (embedding.shape[0] // batch["image"].shape[0])
                         * len(self.trainer.train_dataloader.dataset)
                         * self.trainer.max_epochs,
                         *embedding.shape[1:],


### PR DESCRIPTION
## Description

### Fixed

- Fix wrong embeddings initialization in patchcore when the dataset is smaller than the batch size.

